### PR TITLE
tnt macOS 10.13 fix

### DIFF
--- a/recipies/geos/build.sh
+++ b/recipies/geos/build.sh
@@ -2,6 +2,8 @@
 
 mv $SRC_DIR/README.md $SRC_DIR/README
 
+sed -i '/-ansi/d' configure.ac
+
 if [ ! -f configure ]; then
   autoreconf -i --force
 fi
@@ -23,7 +25,6 @@ if [ $(uname) == Darwin ]; then
   export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
   export CXXFLAGS="$CXXFLAGS -stdlib=libc++"
 fi
-
 
 ./configure --prefix=$PREFIX
 

--- a/recipies/nn/build.sh
+++ b/recipies/nn/build.sh
@@ -13,7 +13,7 @@ make install
 if [ $(uname) == "Linux" ]; then
   echo "================================="
   echo "Linux shared object being created..."
-  gcc -shared -o libnn.so -L${PREFIX}/lib -lnn
+  gcc -shared -o libnn.so *.o -L${PREFIX}/lib -lnn
   cp libnn.so ${PREFIX}/lib
 fi
 

--- a/recipies/nn/build.sh
+++ b/recipies/nn/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+mkdir -p ${PREFIX}/bin
+mkdir -p ${PREFIX}/lib
+mkdir -p ${PREFIX}/nn/include
+
+cd nn
+
+./configure --prefix=${PREFIX} CFLAGS="-fPIC" 
+make
+make install
+
+if [ $(uname) == "Linux" ]; then
+  echo "================================="
+  echo "Linux shared object being created..."
+  gcc -shared -o libnn.so -L${PREFIX}/lib -lnn
+  cp libnn.so ${PREFIX}/lib
+fi
+
+if [ $(uname) == "Darwin" ]; then
+  clang -dynamiclib -o libnn.dylib -L${PREFIX}/lib -lnn
+  cp libnn.dylib ${PREFIX}/lib
+fi

--- a/recipies/nn/build.sh
+++ b/recipies/nn/build.sh
@@ -18,6 +18,6 @@ if [ $(uname) == "Linux" ]; then
 fi
 
 if [ $(uname) == "Darwin" ]; then
-  clang -dynamiclib -o libnn.dylib -L${PREFIX}/lib -lnn
+  clang -dynamiclib -o libnn.dylib *.o -L${PREFIX}/lib -lnn
   cp libnn.dylib ${PREFIX}/lib
 fi

--- a/recipies/nn/meta.yaml
+++ b/recipies/nn/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: nn
+  version: 1.86.0
+
+source:
+  url: https://github.com/sakov/nn-c/archive/master.zip
+

--- a/recipies/nn/meta.yaml.tmpl
+++ b/recipies/nn/meta.yaml.tmpl
@@ -1,0 +1,8 @@
+package:
+  name: nn
+  version: {{ package_versions.nn }}
+
+source:
+  url: https://github.com/sakov/nn-c/archive/master.zip
+
+

--- a/recipies/tnt/README.md
+++ b/recipies/tnt/README.md
@@ -1,0 +1,58 @@
+The files present in this recipe (listed below) have been modified to compile fix a macOS 10.13 build error.
+The modified files are:
+
+* tnt_array1d.h
+* tnt_math_utils.h
+* tnt_sparse_matrix_csr.h
+
+macOS 10.13 ERROR (isis3 [cmake] branch as of 3 September 2018):
+
+```
+Building CXX object objects/CMakeFiles/ForstnerOperator.dir/base/objs/ForstnerOperator/ForstnerOperator.cpp.o
+FAILED: objects/CMakeFiles/ForstnerOperator.dir/base/objs/ForstnerOperator/ForstnerOperator.cpp.o 
+/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DForstnerOperator_EXPORTS -DISISBUILDDIR=\"/Volumes/Scratch/ISIS_Builds/cmake_test_2/ISIS3/build\" -DISISROOT=\mes/Scratch/ISIS_Builds/cmake_test_2/ISIS3/isis\" -DQT_CONCURRENT_LIB -DQT_CORE_LIB -DQT_GUI_LIB -DQT_MULTIMEDIAWIDGETS_LIB -DQT_MULTIMEDIA_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_PRINTSUPIB -DQT_QML_LIB -DQT_QUICK_LIB -DQT_SCRIPTTOOLS_LIB -DQT_SCRIPT_LIB -DQT_SQL_LIB -DQT_SVG_LIB -DQT_TESTCASE_BUILDDIR=\"/Volumes/Scratch/ISIS_Builds/cmake_test_2/ISIS3/build\" -DQT_TESTLIB_LIB -DQT_WEBCHANB -DQT_WIDGETS_LIB -DQT_XMLPATTERNS_LIB -DQT_XML_LIB -isystem /Users/kberry/anaconda3/envs/ISIS3/include/boost -isystem /Users/kberry/anaconda3/envs/ISIS3/include -isystem /Users/kberry/anaconda3/envs/ISIlude/bullet -isystem /Users/kberry/anaconda3/envs/ISIS3 -isystem /usr/include/X11 -isystem /Users/kberry/anaconda3/envs/ISIS3/include/cspice -isystem /Users/kberry/anaconda3/envs/ISIS3/include/eigen3 -isyUsers/kberry/anaconda3/envs/ISIS3/include/embree2 -isystem /Users/kberry/anaconda3/envs/ISIS3/include/gmm -isystem /Users/kberry/anaconda3/envs/ISIS3/include/gsl -isystem /Users/kberry/anaconda3/envs/ISISude/jama -isystem /usgs/apps/kakadu/v7_9_1-01762L/managed/all_includes -isystem /usgs/apps/kakadu/v7_9_1-01762L/managed -isystem /Users/kberry/anaconda3/envs/ISIS3/include/opencv -isystem /Users/kberry/an3/envs/ISIS3/include/pcl-1.8/pcl -isystem /Users/kberry/anaconda3/envs/ISIS3/include/pcl-1.8 -isystem /Users/kberry/anaconda3/envs/ISIS3/include/tnt -Iinc -isystem /Users/kberry/anaconda3/envs/ISIS3/inclu-isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtConcurrent -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtCore -isystem /Users/kberry/anaconda3/envs/ISIS3/./mkspecs/macx-clang -isystem /kberry/anaconda3/envs/ISIS3/include/qt/QtGui -isystem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/OpenGL.framework/Headerstem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/AGL.framework/Headers -isystem /Users/kberry/anaconda3/envs/ISIS3/includeMultimediaWidgets -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtMultimedia -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtNetwork -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qdgets -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtOpenGL -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtPrintSupport -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtQml -is/Users/kberry/anaconda3/envs/ISIS3/include/qt/QtQuick -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtScriptTools -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtScript -isystem /Users/kanaconda3/envs/ISIS3/include/qt/QtSql -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtSvg -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtTest -isystem /Users/kberry/anaconda3/envs/ISIS3de/qt/QtWebChannel -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtXmlPatterns -isystem /Users/kberry/anaconda3/envs/ISIS3/include/qt/QtXml -Wall -fPIC -std=c++11 -DISIS_LITTLE_ENDIAN=1 -Wno-unusameter -Wno-overloaded-virtual -DGMM_USES_SUPERLU -DENABLEJP2K=1 -Wall -fPIC -std=c++11 -DISIS_LITTLE_ENDIAN=1 -Wno-unused-parameter -Wno-overloaded-virtual -DGMM_USES_SUPERLU -DENABLEJP2K=1 -fPIC   -fPICgnu++11 -MD -MT objects/CMakeFiles/ForstnerOperator.dir/base/objs/ForstnerOperator/ForstnerOperator.cpp.o -MF objects/CMakeFiles/ForstnerOperator.dir/base/objs/ForstnerOperator/ForstnerOperator.cpp.o.d -ots/CMakeFiles/ForstnerOperator.dir/base/objs/ForstnerOperator/ForstnerOperator.cpp.o -c /Volumes/Scratch/ISIS_Builds/cmake_test_2/ISIS3/isis/src/base/objs/ForstnerOperator/ForstnerOperator.cpp
+In file included from /Volumes/Scratch/ISIS_Builds/cmake_test_2/ISIS3/isis/src/base/objs/ForstnerOperator/ForstnerOperator.cpp:5:
+In file included from /Users/kberry/anaconda3/envs/ISIS3/include/jama/jama_lu.h:4:
+In file included from /Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt.h:55:
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_sparse_matrix_csr.h:97:3: error: no matching constructor for initialization of 'Array1D<int>'
+                rowptr_(M, r), colind_(nz, c), dim1_(M), dim2_(N) {}
+                ^       ~~~~
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_array1d.h:63:11: note: candidate constructor not viable: no known conversion from 'const int *' to 'const int' for 2nd argument; dereference the argument*
+                 Array1D(int n, const T &a);
+                 ^
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_array1d.h:64:11: note: candidate constructor not viable: 2nd argument ('const int *') would lose const qualifier
+                 Array1D(int n,  T *a);
+                 ^
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_array1d.h:62:11: note: candidate constructor not viable: requires single argument 'n', but 2 arguments were provided
+        explicit Array1D(int n);
+                 ^
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_array1d.h:65:14: note: candidate constructor not viable: requires single argument 'A', but 2 arguments were provided
+    inline   Array1D(const Array1D &A);
+             ^
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_array1d.h:61:11: note: candidate constructor not viable: requires 0 arguments, but 2 were provided
+                 Array1D();
+                 ^
+In file included from /Volumes/Scratch/ISIS_Builds/cmake_test_2/ISIS3/isis/src/base/objs/ForstnerOperator/ForstnerOperator.cpp:5:
+In file included from /Users/kberry/anaconda3/envs/ISIS3/include/jama/jama_lu.h:4:
+In file included from /Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt.h:55:
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_sparse_matrix_csr.h:97:18: error: no matching constructor for initialization of 'Array1D<int>'
+                rowptr_(M, r), colind_(nz, c), dim1_(M), dim2_(N) {}
+                               ^       ~~~~~
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_array1d.h:63:11: note: candidate constructor not viable: no known conversion from 'const int *' to 'const int' for 2nd argument; dereference the argument*
+                 Array1D(int n, const T &a);
+                 ^
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_array1d.h:64:11: note: candidate constructor not viable: 2nd argument ('const int *') would lose const qualifier
+                 Array1D(int n,  T *a);
+                 ^
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_array1d.h:62:11: note: candidate constructor not viable: requires single argument 'n', but 2 arguments were provided
+        explicit Array1D(int n);
+                 ^
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_array1d.h:65:14: note: candidate constructor not viable: requires single argument 'A', but 2 arguments were provided
+    inline   Array1D(const Array1D &A);
+             ^
+/Users/kberry/anaconda3/envs/ISIS3/include/tnt/tnt_array1d.h:61:11: note: candidate constructor not viable: requires 0 arguments, but 2 were provided
+                 Array1D();
+                 ^
+2 errors generated.
+```
+

--- a/recipies/tnt/build.sh
+++ b/recipies/tnt/build.sh
@@ -2,3 +2,11 @@
 
 mkdir -p ${PREFIX}/include/tnt/
 cp *.h ${PREFIX}/include/tnt/
+
+# This build recipe does NOT currently account for macOS.
+# to fix this, modify add a line below that copies the three files in the
+# isis3_dependencies/recipies/tnt repo,
+# tnt_array1d.h, tnt_math_utils.h, tnt_sparse_matrix_csr.h,
+# to ${PREFIX}/include/tnt/
+# e.g.
+# cp ~/isis3_dependencies/recipies/tnt/*.h ${PREFIX}/include/tnt/

--- a/recipies/tnt/tnt_array1d.h
+++ b/recipies/tnt/tnt_array1d.h
@@ -1,0 +1,278 @@
+/*
+*
+* Template Numerical Toolkit (TNT)
+*
+* Mathematical and Computational Sciences Division
+* National Institute of Technology,
+* Gaithersburg, MD USA
+*
+*
+* This software was developed at the National Institute of Standards and
+* Technology (NIST) by employees of the Federal Government in the course
+* of their official duties. Pursuant to title 17 Section 105 of the
+* United States Code, this software is not subject to copyright protection
+* and is in the public domain. NIST assumes no responsibility whatsoever for
+* its use by other parties, and makes no guarantees, expressed or implied,
+* about its quality, reliability, or any other characteristic.
+*
+*/
+
+
+
+#ifndef TNT_ARRAY1D_H
+#define TNT_ARRAY1D_H
+
+//#include <cstdlib>
+#include <iostream>
+
+#ifdef TNT_BOUNDS_CHECK
+#include <assert.h>
+#endif
+
+
+#include "tnt_i_refvec.h"
+
+namespace TNT
+{
+
+template <class T>
+class Array1D 
+{
+
+  private:
+
+	  /* ... */
+    i_refvec<T> v_;
+    int n_;
+    T* data_;				/* this normally points to v_.begin(), but
+                             * could also point to a portion (subvector)
+							 * of v_.
+                            */
+
+    void copy_(T* p, const T*  q, int len) const;
+    void set_(T* begin,  T* end, const T& val);
+ 
+
+  public:
+
+    typedef         T   value_type;
+
+
+	         Array1D();
+	explicit Array1D(int n);
+	         Array1D(int n, const T &a);
+	         Array1D(int n,  T *a);
+    inline   Array1D(const Array1D &A);
+	inline   operator T*();
+	inline   operator const T*();
+	inline   Array1D & operator=(const T &a);
+	inline   Array1D & operator=(const Array1D &A);
+	inline   Array1D & ref(const Array1D &A);
+	         Array1D copy() const;
+		     Array1D & inject(const Array1D & A);
+	inline   T& operator[](int i);
+	inline   const T& operator[](int i) const;
+	inline 	 int dim1() const;
+	inline   int dim() const;
+              ~Array1D();
+
+
+	/* ... extended interface ... */
+
+	inline int ref_count() const;
+	inline Array1D<T> subarray(int i0, int i1);
+
+};
+
+
+
+
+template <class T>
+Array1D<T>::Array1D() : v_(), n_(0), data_(0) {}
+
+template <class T>
+Array1D<T>::Array1D(const Array1D<T> &A) : v_(A.v_),  n_(A.n_), 
+		data_(A.data_)
+{
+#ifdef TNT_DEBUG
+	std::cout << "Created Array1D(const Array1D<T> &A) \n";
+#endif
+
+}
+
+
+template <class T>
+Array1D<T>::Array1D(int n) : v_(n), n_(n), data_(v_.begin())
+{
+#ifdef TNT_DEBUG
+	std::cout << "Created Array1D(int n) \n";
+#endif
+}
+
+template <class T>
+Array1D<T>::Array1D(int n, const T &val) : v_(n), n_(n), data_(v_.begin()) 
+{
+#ifdef TNT_DEBUG
+	std::cout << "Created Array1D(int n, const T& val) \n";
+#endif
+	set_(data_, data_+ n, val);
+
+}
+
+template <class T>
+Array1D<T>::Array1D(int n, T *a) : v_(a), n_(n) , data_(v_.begin())
+{
+#ifdef TNT_DEBUG
+	std::cout << "Created Array1D(int n, T* a) \n";
+#endif
+}
+
+template <class T>
+inline Array1D<T>::operator T*()
+{
+	return &(v_[0]);
+}
+
+
+template <class T>
+inline Array1D<T>::operator const T*()
+{
+	return &(v_[0]);
+}
+
+
+
+template <class T>
+inline T& Array1D<T>::operator[](int i) 
+{ 
+#ifdef TNT_BOUNDS_CHECK
+	assert(i>= 0);
+	assert(i < n_);
+#endif
+	return data_[i]; 
+}
+
+template <class T>
+inline const T& Array1D<T>::operator[](int i) const 
+{ 
+#ifdef TNT_BOUNDS_CHECK
+	assert(i>= 0);
+	assert(i < n_);
+#endif
+	return data_[i]; 
+}
+
+
+	
+
+template <class T>
+Array1D<T> & Array1D<T>::operator=(const T &a)
+{
+	set_(data_, data_+n_, a);
+	return *this;
+}
+
+template <class T>
+Array1D<T> Array1D<T>::copy() const
+{
+	Array1D A( n_);
+	copy_(A.data_, data_, n_);
+
+	return A;
+}
+
+
+template <class T>
+Array1D<T> & Array1D<T>::inject(const Array1D &A)
+{
+	if (A.n_ == n_)
+		copy_(data_, A.data_, n_);
+
+	return *this;
+}
+
+
+
+
+
+template <class T>
+Array1D<T> & Array1D<T>::ref(const Array1D<T> &A)
+{
+	if (this != &A)
+	{
+		v_ = A.v_;		/* operator= handles the reference counting. */
+		n_ = A.n_;
+		data_ = A.data_; 
+		
+	}
+	return *this;
+}
+
+template <class T>
+Array1D<T> & Array1D<T>::operator=(const Array1D<T> &A)
+{
+	return ref(A);
+}
+
+template <class T>
+inline int Array1D<T>::dim1() const { return n_; }
+
+template <class T>
+inline int Array1D<T>::dim() const { return n_; }
+
+template <class T>
+Array1D<T>::~Array1D() {}
+
+
+/* ............................ exented interface ......................*/
+
+template <class T>
+inline int Array1D<T>::ref_count() const
+{
+	return v_.ref_count();
+}
+
+template <class T>
+inline Array1D<T> Array1D<T>::subarray(int i0, int i1)
+{
+	if (((i0 > 0) && (i1 < n_)) || (i0 <= i1))
+	{
+		Array1D<T> X(*this);  /* create a new instance of this array. */
+		X.n_ = i1-i0+1;
+		X.data_ += i0;
+
+		return X;
+	}
+	else
+	{
+		return Array1D<T>();
+	}
+}
+
+
+/* private internal functions */
+
+
+template <class T>
+void Array1D<T>::set_(T* begin, T* end, const T& a)
+{
+	for (T* p=begin; p<end; p++)
+		*p = a;
+
+}
+
+template <class T>
+void Array1D<T>::copy_(T* p, const T* q, int len) const
+{
+	T *end = p + len;
+	while (p<end )
+		*p++ = *q++;
+
+}
+
+
+} /* namespace TNT */
+
+#endif
+/* TNT_ARRAY1D_H */
+

--- a/recipies/tnt/tnt_math_utils.h
+++ b/recipies/tnt/tnt_math_utils.h
@@ -1,0 +1,39 @@
+#ifndef MATH_UTILS_H
+#define MATH_UTILS_H
+
+/* needed for fabs, sqrt() below */
+#include <cmath>
+
+
+
+namespace TNT
+{
+/**
+	@returns hypotenuse of real (non-complex) scalars a and b by 
+	avoiding underflow/overflow
+	using (a * sqrt( 1 + (b/a) * (b/a))), rather than
+	sqrt(a*a + b*b).
+*/
+template <class Real>
+Real hypot(const Real &a, const Real &b)
+{
+	
+	if (a== 0)
+        {
+                // issues warnings because b is not the right type for abs()
+		//return abs(b);
+
+		return fabs(b);
+        }
+	else
+	{
+		Real c = b/a;
+		return fabs(a) * sqrt(1 + c*c);
+	}
+}
+} /* TNT namespace */
+
+
+
+#endif
+/* MATH_UTILS_H */

--- a/recipies/tnt/tnt_sparse_matrix_csr.h
+++ b/recipies/tnt/tnt_sparse_matrix_csr.h
@@ -1,0 +1,103 @@
+/*
+*
+* Template Numerical Toolkit (TNT)
+*
+* Mathematical and Computational Sciences Division
+* National Institute of Technology,
+* Gaithersburg, MD USA
+*
+*
+* This software was developed at the National Institute of Standards and
+* Technology (NIST) by employees of the Federal Government in the course
+* of their official duties. Pursuant to title 17 Section 105 of the
+* United States Code, this software is not subject to copyright protection
+* and is in the public domain. NIST assumes no responsibility whatsoever for
+* its use by other parties, and makes no guarantees, expressed or implied,
+* about its quality, reliability, or any other characteristic.
+*
+*/
+
+
+#ifndef TNT_SPARSE_MATRIX_CSR_H
+#define TNT_SPARSE_MATRIX_CSR_H
+
+#include "tnt_array1d.h"
+
+namespace TNT
+{
+
+
+/**
+	Read-only view of a sparse matrix in compressed-row storage
+	format.  Neither array elements (nonzeros) nor sparsity
+	structure can be modified.  If modifications are required,
+	create a new view.
+
+	<p>
+	Index values begin at 0.
+
+	<p>
+	<b>Storage requirements:</b> An (m x n) matrix with
+	nz nonzeros requires no more than  ((T+I)*nz + M*I)
+	bytes, where T is the size of data elements and
+	I is the size of integers.
+	
+
+*/
+template <class T>
+class Sparse_Matrix_CompRow {
+
+private:
+	Array1D<T>    val_;       // data values (nz_ elements)
+    Array1D<int>  rowptr_;    // row_ptr (dim_[0]+1 elements)
+    Array1D<int>  colind_;    // col_ind  (nz_ elements)
+
+    int dim1_;        // number of rows
+    int dim2_;        // number of cols
+  
+public:
+
+	Sparse_Matrix_CompRow(const Sparse_Matrix_CompRow &S);
+	Sparse_Matrix_CompRow(int M, int N, int nz, const T *val, 
+						const int *r, const int *c);
+    
+
+
+    inline   const T&      val(int i) const { return val_[i]; }
+    inline   const int&         row_ptr(int i) const { return rowptr_[i]; }
+    inline   const int&         col_ind(int i) const { return colind_[i];}
+
+    inline   int    dim1() const {return dim1_;}
+    inline   int    dim2() const {return dim2_;}
+       int          NumNonzeros() const {return val_.dim1();}
+
+
+    Sparse_Matrix_CompRow& operator=(
+					const Sparse_Matrix_CompRow &R);
+
+
+
+};
+
+/**
+	Construct a read-only view of existing sparse matrix in
+	compressed-row storage format.
+
+	@param M the number of rows of sparse matrix
+	@param N the  number of columns of sparse matrix
+	@param nz the number of nonzeros
+	@param val a contiguous list of nonzero values
+	@param r row-pointers: r[i] denotes the begining position of row i
+		(i.e. the ith row begins at val[row[i]]).
+	@param c column-indices: c[i] denotes the column location of val[i]
+*/
+template <class T>
+Sparse_Matrix_CompRow<T>::Sparse_Matrix_CompRow(int M, int N, int nz,
+	const T *val, const int *r, const int *c) : val_(nz,val), 
+		rowptr_(M, *r), colind_(nz, *c), dim1_(M), dim2_(N) {}
+
+
+}
+// namespace TNT
+
+#endif


### PR DESCRIPTION
This PR version controls the changes needed to patch tnt for macOS 10.13 (see the added ```README.md``` file in the tnt recipe).